### PR TITLE
コマンドライン引数の処理

### DIFF
--- a/hello/src/main.rs
+++ b/hello/src/main.rs
@@ -31,6 +31,7 @@ fn main() {
 
     if numbers.len() == 0 {
         writeln!(std::io::stderr(), "Usage: gcd NUMBER ...").unwrap();
+        std::process::exit(1);
     }
 
 }

--- a/hello/src/main.rs
+++ b/hello/src/main.rs
@@ -19,5 +19,4 @@ fn test_gcd() {
 }
 
 fn main() {
-    println!("Hello, world!");
 }

--- a/hello/src/main.rs
+++ b/hello/src/main.rs
@@ -24,7 +24,7 @@ fn test_gcd() {
 fn main() {
     let mut numbers = Vec::new();
 
-    for arg in std::env::args() {
+    for arg in std::env::args().skip(1) {
         println!("{}", arg);
         numbers.push(u64::from_str(&arg)
                     .expect("error parsing argument"));

--- a/hello/src/main.rs
+++ b/hello/src/main.rs
@@ -39,4 +39,6 @@ fn main() {
         d = gcd(d, *m);
     }
 
+    println!("The greatest common divisor of {:?} is {}",
+            numbers, d);
 }

--- a/hello/src/main.rs
+++ b/hello/src/main.rs
@@ -25,6 +25,7 @@ fn main() {
     let mut numbers = Vec::new();
 
     for arg in std::env::args() {
+        println!("{}", arg);
         numbers.push(u64::from_str(&arg)
                     .expect("error parsing argument"));
     }

--- a/hello/src/main.rs
+++ b/hello/src/main.rs
@@ -34,4 +34,9 @@ fn main() {
         std::process::exit(1);
     }
 
+    let mut d = numbers[0];
+    for m in &numbers[1..] {
+        d = gcd(d, *m);
+    }
+
 }

--- a/hello/src/main.rs
+++ b/hello/src/main.rs
@@ -25,7 +25,6 @@ fn main() {
     let mut numbers = Vec::new();
 
     for arg in std::env::args().skip(1) {
-        println!("{}", arg);
         numbers.push(u64::from_str(&arg)
                     .expect("error parsing argument"));
     }

--- a/hello/src/main.rs
+++ b/hello/src/main.rs
@@ -25,5 +25,7 @@ fn main() {
     let mut numbers = Vec::new();
 
     for arg in std::env::args() {
+        numbers.push(u64::from_str(&arg)
+                    .expect("error parsing argument"));
     }
 }

--- a/hello/src/main.rs
+++ b/hello/src/main.rs
@@ -24,4 +24,6 @@ fn test_gcd() {
 fn main() {
     let mut numbers = Vec::new();
 
+    for arg in std::env::args() {
+    }
 }

--- a/hello/src/main.rs
+++ b/hello/src/main.rs
@@ -28,4 +28,8 @@ fn main() {
         numbers.push(u64::from_str(&arg)
                     .expect("error parsing argument"));
     }
+
+    if numbers.len() == 0 {
+    }
+
 }

--- a/hello/src/main.rs
+++ b/hello/src/main.rs
@@ -22,4 +22,6 @@ fn test_gcd() {
 }
 
 fn main() {
+    let mut numbers = Vec::new();
+
 }

--- a/hello/src/main.rs
+++ b/hello/src/main.rs
@@ -30,6 +30,7 @@ fn main() {
     }
 
     if numbers.len() == 0 {
+        writeln!(std::io::stderr(), "Usage: gcd NUMBER ...").unwrap();
     }
 
 }

--- a/hello/src/main.rs
+++ b/hello/src/main.rs
@@ -1,3 +1,6 @@
+use std::io::Write;
+use std::str::FromStr;
+
 fn gcd(mut n: u64, mut m: u64) -> u64 {
     assert!(n != 0 && m != 0);
     while m != 0 {


### PR DESCRIPTION
## Note

- std::env::args().skip(1) で一番目はスキップ